### PR TITLE
change write file mode

### DIFF
--- a/cli/generator/generator.go
+++ b/cli/generator/generator.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	GenerateFunction = "template.Generate"
-	writeFileMode    = 0222
+	writeFileMode    = 0644
 )
 
 // Generate outputs the generated code (with gofmt).


### PR DESCRIPTION
in mac m1:
```
copygen -yml ./setup.yml
ls -l
```
show
```
➜  copygen git:(master) ✗ ls -l
total 8
--w-------  1 yoogo  staff  660  5 25 10:05 copygen.go
drwxr-xr-x  3 yoogo  staff   96  5 25 09:25 domains
drwxr-xr-x  3 yoogo  staff   96  5 25 09:25 models
drwxr-xr-x  4 yoogo  staff  128  5 25 09:29 setup
```
continue execute `cat copygen.go`:
```
➜  copygen git:(master) ✗ cat copygen.go
cat: copygen.go: Permission denied
```

but other pc no problem。。。。
