### PR TITLE
Fix spacing in basic example

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -27,10 +27,9 @@ package models
 type Account struct {
 	ID       int
 	Name     string
-    Email    string
+        Email    string
 	Password string
 }
-
 ```
 
 ## YML


### PR DESCRIPTION
### Description

Just fixing the spacing here since it wasn't formatted correctly with the monospacing.