### PR TITLE
implement feature to map functions 

### DIFF
--- a/cli/parser/function.go
+++ b/cli/parser/function.go
@@ -31,8 +31,8 @@ func (p *Parser) parseFunctions(copygen *ast.InterfaceType) ([]models.Function, 
 		}
 
 		// set the options for each field.
-		setTypeOptions(parsed.fromTypes, fieldoptions)
-		setTypeOptions(parsed.toTypes, fieldoptions)
+		setTypeOptions(parsed.fromTypes, fieldoptions, method.Name())
+		setTypeOptions(parsed.toTypes, fieldoptions, method.Name())
 
 		// map the function custom options.
 		customoptionmap := make(map[string][]string)
@@ -90,10 +90,10 @@ func getNodeOptions(x ast.Node, commentoptionmap map[string]*options.Option) ([]
 }
 
 // setTypeOptions sets the options for all fields in the given types.
-func setTypeOptions(types []models.Type, fieldoptions []*options.Option) {
+func setTypeOptions(types []models.Type, fieldoptions []*options.Option, functionName string) {
 	for _, t := range types {
 		for _, field := range t.Field.AllFields(nil, nil) {
-			options.SetFieldOptions(field, fieldoptions)
+			options.SetFieldOptions(field, fieldoptions, functionName)
 			options.FilterDepth(field, field.Options.Depth, 0)
 		}
 	}

--- a/cli/parser/options/convert.go
+++ b/cli/parser/options/convert.go
@@ -43,15 +43,18 @@ func ParseConvert(option, value string) (*Option, error) {
 }
 
 // SetConvert sets a field's convert option.
-func SetConvert(field *models.Field, option Option) {
+func SetConvert(field *models.Field, option Option, functionName string) {
 	// A convert option can only be set to a field once.
 	if field.Options.Convert != "" {
 		return
 	}
 
-	if option.Regex[1] != nil && option.Regex[1].MatchString(field.FullNameWithoutPointer("")) {
-		if value, ok := option.Value.(string); ok {
-			field.Options.Convert = value
+	if option.Regex[0] != nil && option.Regex[0].MatchString(functionName) {
+		if option.Regex[1] != nil && option.Regex[1].MatchString(field.FullNameWithoutPointer("")) {
+			if value, ok := option.Value.(string); ok {
+				field.Options.Convert = value
+			}
 		}
 	}
+
 }

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -55,7 +55,7 @@ func NewFieldOption(category, text string) (*Option, error) {
 }
 
 // SetFieldOptions sets a field's (and its subfields) options.
-func SetFieldOptions(field *models.Field, fieldoptions []*Option) {
+func SetFieldOptions(field *models.Field, fieldoptions []*Option, functionName string) {
 	for _, option := range fieldoptions {
 
 		switch option.Category {
@@ -70,7 +70,7 @@ func SetFieldOptions(field *models.Field, fieldoptions []*Option) {
 			SetTag(field, *option)
 
 		case CategoryConvert:
-			SetConvert(field, *option)
+			SetConvert(field, *option, functionName)
 
 		case CategoryDepth:
 			SetDepth(field, *option)
@@ -79,7 +79,7 @@ func SetFieldOptions(field *models.Field, fieldoptions []*Option) {
 			SetDeepcopy(field, *option)
 
 		case CategoryCustom:
-			SetConvert(field, *option)
+			SetConvert(field, *option, functionName)
 		}
 	}
 }


### PR DESCRIPTION
the documentation says: " CONVERT: /* Define the function and field this converter is applied to using regex. */' but comments like a "convert .* models.User.UserID" does not match functions on parsing stage. In code we have already done mechnics to map functions from comment. I add passing "parsed" function name in convert option setter, where use predefine (in option) regex to match func name